### PR TITLE
Skip properly any non numerical value

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ module.exports = function (app) {
             })
           }
           else {
-            if (isNaN(values) || values == null || isNaN(parseFloat(u.values))) {
+            if (isNaN(values) || values == null || isNaN(parseFloat(values))) {
               return
             }
             else {

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ module.exports = function (app) {
             })
           }
           else {
-            if (isNaN(values) || !isfloatField(values)) {
+            if (isNaN(values) || !isfloatField(values) || !isFinite(values)) {
               app.debug(`Skipping path '${path}' because values is invalid, '${values}'`)
               return
             }

--- a/index.js
+++ b/index.js
@@ -74,8 +74,7 @@ module.exports = function (app) {
   let influxFormat = function(path,values,signalkTimestamp,options) {
       app.debug(`Processing path '${path}'`)
       if (!isfloatField(values)) {
-        app.debug(`invalid values for path ${path}`)
-        app.debug(`with {"value":${values}}`)
+        app.debug(`invalid values for path '${path}' with value '${values}'`)
         return
       }
 	  

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ module.exports = function (app) {
           }
           else {
             if (isNaN(values)) {
-              app.debug(`Skipping path ${path} because values is invalid, "${value}"`)
+              app.debug(`Skipping path ${path} because values is invalid, "${values}"`)
               return
             }
             else {

--- a/index.js
+++ b/index.js
@@ -67,7 +67,18 @@ module.exports = function (app) {
     }
   }
 
+  let isfloatField = function(n) {
+      return Number(n) === n;	  
+  }
+
   let influxFormat = function(path,values,signalkTimestamp,options) {
+      app.debug(`Processing path '${path}'`)
+      if (!isfloatField(values)) {
+        app.debug(`invalid values for path ${path}`)
+        app.debug(`with {"value":${values}}`)
+        return
+      }
+	  
       const measurement = path
       const fields = {"value":values}
       const timestamp = Date.parse(signalkTimestamp)
@@ -141,7 +152,7 @@ module.exports = function (app) {
       delta => {
         delta.updates.forEach(u => {
           //if no u.values then return as there is no values to display
-          if (!u.values || u.values == null) {
+          if (!u.values) {
             return
           }
 
@@ -163,7 +174,7 @@ module.exports = function (app) {
             })
           }
           else {
-            if (isNaN(values) || values == null || isNaN(parseFloat(values))) {
+            if (isNaN(values)) {
               app.debug(`Skipping path ${path} because values is invalid, "${value}"`)
               return
             }

--- a/index.js
+++ b/index.js
@@ -7,19 +7,13 @@ module.exports = function (app) {
 
   let unsubscribes = []
 
-
   let metricArray = []
   let bufferArray = []
 
   let influxUploadTimer
 
-
-
   let vesselname = app.getSelfPath('name')
   let vesselfleet = app.getSelfPath('fleet')
-
-
-  
 
   let modifyPath = function(path,values,signalkTimestamp,options) {
     if (path == "navigation.position") {
@@ -59,7 +53,7 @@ module.exports = function (app) {
       //influxFormat(pathRoll,valueRoll,timestamp,options)
       //influxFormat(pathPitch,valuePitch,timestamp,options)
       //influxFormat(pathYaw,valueYaw,timestamp,options)
-    }    
+    }
   }
 
 
@@ -72,7 +66,6 @@ module.exports = function (app) {
       return true
     }
   }
-  
 
   let influxFormat = function(path,values,signalkTimestamp,options) {
       const measurement = path
@@ -111,7 +104,7 @@ module.exports = function (app) {
 
   let _start = function(options) {
     app.debug(`${plugin.name} Started...`)
-    
+
     //Set Variables from plugin options
     const url = options["influxHost"]
     const token = options["influxToken"]
@@ -126,7 +119,7 @@ module.exports = function (app) {
 
     })
 
-    //Create InfluxDB 
+    //Create InfluxDB
     const writeApi = new InfluxDB({
     	url,
     	token})
@@ -175,9 +168,8 @@ module.exports = function (app) {
               return
             }
             else {
-              	writeApi.writePoint(influxFormat(path,values,timestamp,options))           
+              	writeApi.writePoint(influxFormat(path,values,timestamp,options))
             }
-          
           }
 
         });
@@ -195,7 +187,7 @@ module.exports = function (app) {
         //clearInterval(influxUploadTimer);
     //}
     //// clean up the state
-    //influxUploadTimer = undefined;    
+    //influxUploadTimer = undefined;
   //}
 	}
 
@@ -217,22 +209,22 @@ module.exports = function (app) {
 	         "influxHost":{
 	            "type":"string",
 	            "title":"Influxdb2.0 Host URL",
-              "description": "the url to your cloud hosted influxb2.0"
+	            "description": "the url to your cloud hosted influxb2.0"
 	         },
 	         "influxToken":{
 	            "type":"string",
 	            "title":"Influxdb2.0 Token",
-              "description": "the token for your cloud hosted influxb2.0 bucket"
+	            "description": "the token for your cloud hosted influxb2.0 bucket"
 	         },
 	         "influxOrg":{
 	            "type":"string",
 	            "title":"Influxdb2.0 Organisation",
-              "description": "your influxdb2.0 organistion"
+	            "description": "your influxdb2.0 organistion"
 	         },
 	         "influxBucket":{
 	            "type":"string",
 	            "title":"Influxdb2.0 Bucket",
-              "description": "which bucket you are storing the metrics in"
+	            "description": "which bucket you are storing the metrics in"
 	         },
 	         "writeOptions":{
 	            "type":"object",
@@ -250,43 +242,43 @@ module.exports = function (app) {
 	               "batchSize":{
 	                  "type":"number",
 	                  "title":"Batch Size",
-                    "description": "the maximum points/line to send in a single batch to InfluxDB server",
-	                  "default": 1000	           
+	                  "description": "the maximum points/line to send in a single batch to InfluxDB server",
+	                  "default": 1000
 	               },
 	               "flushInterval":{
 	                  "type":"number",
 	                  "title":"Flush Interval",
-                    "description": "maximum time in millis to keep points in an unflushed batch, 0 means don't periodically flush",
+	                  "description": "maximum time in millis to keep points in an unflushed batch, 0 means don't periodically flush",
 	                  "default": 30000
 	               },
 	               "maxBufferLines":{
 	                  "type":"number",
 	                  "title":"Maximum Buffer Lines",
-                    "description": "maximum size of the retry buffer - it contains items that could not be sent for the first time",
+	                  "description": "maximum size of the retry buffer - it contains items that could not be sent for the first time",
 	                  "default": 32000
 	               },
 	               "maxRetries":{
 	                  "type":"number",
 	                  "title":"Maximum Retries",
-                    "description": "maximum delay between retries in milliseconds",
+	                  "description": "maximum delay between retries in milliseconds",
 	                  "default": 3
 	               },
 	               "maxRetryDelay":{
 	                  "type":"number",
 	                  "title":"Maximum Retry Delay",
-                    "description": "maximum delay between retries in milliseconds",
+	                  "description": "maximum delay between retries in milliseconds",
 	                  "default": 5000
 	               },
 	               "minRetryDelay":{
 	                  "type":"number",
 	                  "title":"Minimum Retry Delay",
-                    "description": "minimum delay between retries in milliseconds",
+	                  "description": "minimum delay between retries in milliseconds",
 	                  "default": 180000
 	               },
 	               "retryJitter":{
 	                  "type":"number",
 	                  "title":"Retry Jitter",
-                    "description": "a random value of up to retryJitter is added when scheduling next retry",
+	                  "description": "a random value of up to retryJitter is added when scheduling next retry",
 	                  "default": 200
 	               }
 	           }
@@ -296,28 +288,26 @@ module.exports = function (app) {
 	            "title": "Default Tags",
 	            "items": {
 	            	"type": "object",
-					"required":[
-						"tagName",
-						"tagValue"
-					],
-					"properties":{
+			"required":[
+				"tagName",
+				"tagValue"
+			],
+			"properties":{
 	                  "tagName":{
 	                     "type":"string",
 	                     "title":"Tag Name"
 	                  },
 	                  "tagValue":{
 	                     "type":"string",
-	                     "title":"Tag Value"			                     
-	                  }						
-					}	            	
+	                     "title":"Tag Value"
+	                  }
+			}
 	            }
-
 	         },
 	         "pathArray":{
 	            "type":"array",
 	            "title":"Paths",
 	            "default":[
-	               
 	            ],
 	            "items":{
 	               "type":"object",

--- a/index.js
+++ b/index.js
@@ -144,10 +144,6 @@ module.exports = function (app) {
           if (!u.values || u.values == null) {
             return
           }
-          // Avoid Error: Expected float value for field value but got string
-          if (isNaN(parseFloat(u.values))) {
-            return
-          }
 
           const path = u.values[0].path
           const values = u.values[0].value
@@ -167,7 +163,7 @@ module.exports = function (app) {
             })
           }
           else {
-            if (isNaN(values) || values == null) {
+            if (isNaN(values) || values == null || isNaN(parseFloat(u.values))) {
               return
             }
             else {

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ module.exports = function (app) {
       delta => {
         delta.updates.forEach(u => {
           //if no u.values then return as there is no values to display
-          if (!u.values) {
+          if (!u.values || u.values == null) {
             return
           }
 
@@ -160,18 +160,16 @@ module.exports = function (app) {
               else {
                 writeApi.writePoint(influxFormat(seperatePath.path,seperatePath.value,seperatePath.timestamp,options))
               }
-              
             })
           }
           else {
-            if (isNaN(values)) {
+            if (isNaN(values) || values == null) {
               return
             }
             else {
               	writeApi.writePoint(influxFormat(path,values,timestamp,options))
             }
           }
-
         });
       }
     );

--- a/index.js
+++ b/index.js
@@ -71,13 +71,7 @@ module.exports = function (app) {
       return Number(n) === n;	  
   }
 
-  let influxFormat = function(path,values,signalkTimestamp,options) {
-      app.debug(`Processing path '${path}'`)
-      if (!isfloatField(values)) {
-        app.debug(`invalid values for path '${path}' with value '${values}'`)
-        return
-      }
-	  
+  let influxFormat = function(path,values,signalkTimestamp,options) { 
       const measurement = path
       const fields = {"value":values}
       const timestamp = Date.parse(signalkTimestamp)
@@ -173,8 +167,8 @@ module.exports = function (app) {
             })
           }
           else {
-            if (isNaN(values)) {
-              app.debug(`Skipping path ${path} because values is invalid, "${values}"`)
+            if (isNaN(values) || !isfloatField(values)) {
+              app.debug(`Skipping path '${path}' because values is invalid, '${values}'`)
               return
             }
             else {

--- a/index.js
+++ b/index.js
@@ -144,6 +144,10 @@ module.exports = function (app) {
           if (!u.values || u.values == null) {
             return
           }
+          // Avoid Error: Expected float value for field value but got string
+          if (isNaN(parseFloat(u.values))) {
+            return
+          }
 
           const path = u.values[0].path
           const values = u.values[0].value
@@ -180,14 +184,13 @@ module.exports = function (app) {
     unsubscribes.forEach(f => f());
     unsubscribes = [];
 
-
-    //if (influxUploadTimer) {
-        //clearInterval(influxUploadTimer);
-    //}
-    //// clean up the state
-    //influxUploadTimer = undefined;
-  //}
-	}
+//if (influxUploadTimer) {
+//clearInterval(influxUploadTimer);
+//}
+//// clean up the state
+//influxUploadTimer = undefined;
+//}
+ }
 
 
  const plugin = {
@@ -330,8 +333,8 @@ module.exports = function (app) {
 	      }
 
 	   },
-	   	start: _start,
-	    stop: _stop
+	   start: _start,
+	   stop: _stop
 	}
   
 return plugin

--- a/index.js
+++ b/index.js
@@ -164,10 +164,11 @@ module.exports = function (app) {
           }
           else {
             if (isNaN(values) || values == null || isNaN(parseFloat(values))) {
+              app.debug(`Skipping path ${path} because values is invalid, "${value}"`)
               return
             }
             else {
-              	writeApi.writePoint(influxFormat(path,values,timestamp,options))
+              writeApi.writePoint(influxFormat(path,values,timestamp,options))
             }
           }
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-to-influxdb-v2-buffering",
-  "version": "1.0.2",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-to-influxdb-v2-buffering",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
`derived-data` and `freeboard-sk-helper` plugins generate new entries that can be null or a string. It should be ignored.

- Clean up empty lines and extra space
- Skip sending null values, `Error: Expected float value for field value but got null` at exports.Point.floatField
- Skip sending non float values, avoid `Error: Expected float value for field value but got "string"` at exports.Point.floatField

